### PR TITLE
Make knex a peer dependency

### DIFF
--- a/packages/db-model/package.json
+++ b/packages/db-model/package.json
@@ -61,7 +61,6 @@
   "dependencies": {
     "camelcase-keys": "^6.2.2",
     "debug": "4.1.1",
-    "knex": "0.20.14",
     "ramda": "^0.27.0",
     "snakecase-keys": "^3.2.0"
   },
@@ -76,6 +75,7 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "husky": "^4.2.5",
+    "knex": "0.20.14",
     "lint-staged": "^10.1.3",
     "mocha": "^7.1.1",
     "nyc": "^15.0.1",
@@ -87,5 +87,8 @@
     "tslint-config-prettier": "^1.18.0",
     "tslint-no-unused-expression-chai": "^0.1.4",
     "typescript": "^3.8.3"
+  },
+  "peerDependencies": {
+    "knex": ">= 0.20.14"
   }
 }


### PR DESCRIPTION
`knex` should be a dev dependency and should allow the end users to install `knex` themselves. This way `knex` conflicts or type mismatch in TypeScript doesn't happen.